### PR TITLE
Variance

### DIFF
--- a/preprocessor_firmware/docs/CommInterface.md
+++ b/preprocessor_firmware/docs/CommInterface.md
@@ -69,6 +69,10 @@ Currently there are 15 variables that can be accessed:
 
   "adcAveraging" a integer that sets how many samples the adc averages over
 
+  "validMean" a float. Its the maximum distance from the desiredPeak for the calibration to consider the mean of the signal valid.
+
+  "validVariance" a float. The maximum distance from zero that the variance can be for the calibration to consider the variance valid.
+
 ### Arguments
 
 Arguments are used in the case of a "set" command
@@ -93,12 +97,14 @@ After a ping, the gain controller will send some feed back informatio;
 
   "peakLevel" a float with 2 decimal precision. The current peak level of the peak detector
 
-  "error" a float with 2 decimal precision. The "error" of the controller
-
   "avgPkLv" a float with 2 decimal precision. The average peak level of the last ping.
+
+  "variance" a float with 5 decimal precision. The variance of the peak level of the last ping.
 
   "samples" a integer. The amount of peak detector samples, and thus the amount times gain control looped during the ping.
 
-Example: "$ping cal=0 gain=40.45 peakLevel=1.23 error=0.19 avgPkLv=1.28 samples=19"
+
+
+Example: "$ping cal=0 gain=40.45 peakLevel=1.23 avgPkLv=1.28 variance=0.00567 samples=19"
 
 Note: There's a new line character at the end of the string

--- a/preprocessor_firmware/src/CommInterface.cpp
+++ b/preprocessor_firmware/src/CommInterface.cpp
@@ -368,6 +368,12 @@ void CommInterface::setValue( void ){
         case 16:
             gainControl->setADCAveraging(output_int);
             break;
+        case 17:
+            gainControl->setValidMean(output_float);
+            break;
+        case 18:
+            gainControl->setValidVariance(output_float);
+            break;
         default:
             //Do nothing
             break;
@@ -382,6 +388,9 @@ void CommInterface::sendLocalVariable( void ){
     switch(variableIndex){
         case 0:
             output_float = gainControl->getDesiredPeak();
+            break;
+        case 1:
+            output_int = gainControl->getHoldGain();
             break;
         case 2:
             output_float = gainControl->getProportionalGain();
@@ -403,6 +412,12 @@ void CommInterface::sendLocalVariable( void ){
             break;
         case 16:
             output_int = gainControl->getADCAveraging();
+            break;
+        case 17:
+            output_float = gainControl->getValidMean();
+            break;
+        case 18:
+            output_float = gainControl->getValidVariance();
         default:
             //Do nothing
             break;
@@ -421,7 +436,8 @@ bool CommInterface::validIncommingSerialMessage( void ){
 void CommInterface::prepareTransmission( void ){
 
     //variable index 13 and 14 are pingStatus and centerFreq respectively
-    if ( (variableIndex == 13) || (variableIndex == 14 || (variableIndex == 16)) ){
+    if ( (variableIndex == 13) || (variableIndex == 14) || (variableIndex == 16)
+                                || ( variableIndex == 1) ){
         Serial.print("$");
         Serial.println(output_int);
     } else {

--- a/preprocessor_firmware/src/CommInterface.h
+++ b/preprocessor_firmware/src/CommInterface.h
@@ -11,7 +11,7 @@
 #include "Filter.h"
 
 #define NUMBER_COMMANDS 2
-#define NUMBER_VARIABLES 17
+#define NUMBER_VARIABLES 19
 
 class CommInterface {
 
@@ -75,7 +75,8 @@ class CommInterface {
             String( F("iGain")), String( F("iSaturation")), String( F("floorGainDur")), String( F("nudgeGainDur")),
             String( F("invalidPingDur")), String( F("nudgeGainValue")), String( F("validPingStart")),
             String( F("validPingEnd")), String( F("gain") ) , String( F("peakLevel") ), String( F("pingStatus")),
-            String( F("centerFreq") ), String( F("debug") ), String( F("adcAveraging"))
+            String( F("centerFreq") ), String( F("debug") ), String( F("adcAveraging")),
+            String( F("validMean")), String( F("validVariance"))
         };
 
         //bool testLED;

--- a/preprocessor_firmware/src/GainControl.cpp
+++ b/preprocessor_firmware/src/GainControl.cpp
@@ -32,6 +32,13 @@ GainControl::GainControl( void ){
     //Set up the invalid ping duration time
     this->GainControl::setInvalidPingDuration( INVALID_PING_DURATION );
 
+    //Set the default nudge gain value
+    this->GainControl::setNudgeGainValue( NUDGE_VALUE );
+
+    //Set up the validMean and validVariance
+    this->GainControl::setValidMean( DEFAULT_VALIDMEAN );
+    this->GainControl::setValidVariance( DEFAULT_VALIDVARIANCE );
+
     //Flag that indicates if we have purposely set the gain to 0dB
     //to kill the signal.
     gainFlooredFlag = false;
@@ -190,11 +197,13 @@ void GainControl::runtime( void ){
             if( this->GainControl::checkCalibration() ){
                 Serial.println( "$ping cal=1 gain=" + String(optimalGain) +
                 " peakLevel=" + String(peakLevel) + " error=" + String(error) +
-                " avgPkLv=" + String(averagePeakLevel) + " samples=" + String(averagePeakLevelCounter));
+                " avgPkLv=" + String(averagePeakLevel) + " variance=" + String(variance) +
+                " samples=" + String(averagePeakLevelCounter));
             } else {
                 Serial.println( "$ping cal=0 gain=" + String(optimalGain) +
                 " peakLevel=" + String(peakLevel) + " error=" + String(error) +
-                " avgPkLv=" + String(averagePeakLevel) + " samples=" + String(averagePeakLevelCounter));
+                " avgPkLv=" + String(averagePeakLevel) + " variance=" + String(variance) +
+                " samples=" + String(averagePeakLevelCounter));
             }
             averagePeakLevelCounter = 0;
             averagePeakLevel = 0;
@@ -215,6 +224,8 @@ void GainControl::gainController( void ){
     //Sum the peakLevel so we can average it
     averagePeakLevel += peakLevel;
     averagePeakLevelCounter++;
+    averagePeakLevelSquared += (peakLevel * peakLevel);
+    averagePeakLevelSquaredCounter++;
 
     //get the integral error
     this->GainControl::getIntegralError();
@@ -257,6 +268,10 @@ void GainControl::saturateGain( void ){
 
 }
 
+void GainControl::calculateVariance( void ){
+    variance = averagePeakLevelSquared - (averagePeakLevel * averagePeakLevel);
+}
+
 //Set desired peak to peak output in mV
 void GainControl::setDesiredPeak2Peak( float input ){
 
@@ -279,7 +294,18 @@ bool GainControl::checkCalibration( void ){
         averagePeakLevel = peakLevel;
     }
 
-    if ( (averagePeakLevel > (desiredPeak-0.1)) && (averagePeakLevel < (desiredPeak + 0.1)) && (error < 0.1) && (error > -0.1)){
+    if (averagePeakLevelSquaredCounter != 0){
+        averagePeakLevelSquared = averagePeakLevelSquared / averagePeakLevelSquaredCounter;
+    } else {
+        averagePeakLevelSquared = peakLevel * peakLevel;
+    }
+
+    this->GainControl::calculateVariance();
+
+    if ( (averagePeakLevel > (desiredPeak-validMean))
+                                                && (averagePeakLevel < (desiredPeak + validMean))
+                                                && (variance < validVariance)
+                                                && (variance > (-1*validVariance)) ) {
         return true;
     } else {
         return false;
@@ -329,8 +355,20 @@ void GainControl::setGain( float gain ){
     setAmplifierGain( gain );
 }
 
+void GainControl::setValidMean( float _validMean ){
+    validMean = _validMean;
+}
+
+void GainControl::setValidVariance( float _variance ){
+    variance = _variance;
+}
+
 float GainControl::getDesiredPeak( void ){
     return desiredPeak;
+}
+
+bool GainControl::getHoldGain( void ){
+    return holdGainFlag;
 }
 
 float GainControl::getCurrentOptimalGain( void ){
@@ -355,4 +393,12 @@ float GainControl::getProportionalGain( void ){
 
 float GainControl::getIntegralGain( void ) {
     return iGain;
+}
+
+float GainControl::getValidMean( void ){
+    return validMean;
+}
+
+float GainControl::getValidVariance( void ){
+    return validVariance;
 }

--- a/preprocessor_firmware/src/GainControl.cpp
+++ b/preprocessor_firmware/src/GainControl.cpp
@@ -196,12 +196,12 @@ void GainControl::runtime( void ){
             serialPingRecievedTimer = millis();
             if( this->GainControl::checkCalibration() ){
                 Serial.println( "$ping cal=1 gain=" + String(optimalGain) +
-                " peakLevel=" + String(peakLevel) + " error=" + String(error) +
+                " peakLevel=" + String(peakLevel) +
                 " avgPkLv=" + String(averagePeakLevel) + " variance=" + String(variance, 5) +
                 " samples=" + String(averagePeakLevelCounter));
             } else {
                 Serial.println( "$ping cal=0 gain=" + String(optimalGain) +
-                " peakLevel=" + String(peakLevel) + " error=" + String(error) +
+                " peakLevel=" + String(peakLevel) +
                 " avgPkLv=" + String(averagePeakLevel) + " variance=" + String(variance, 5) +
                 " samples=" + String(averagePeakLevelCounter));
             }

--- a/preprocessor_firmware/src/GainControl.cpp
+++ b/preprocessor_firmware/src/GainControl.cpp
@@ -197,16 +197,19 @@ void GainControl::runtime( void ){
             if( this->GainControl::checkCalibration() ){
                 Serial.println( "$ping cal=1 gain=" + String(optimalGain) +
                 " peakLevel=" + String(peakLevel) + " error=" + String(error) +
-                " avgPkLv=" + String(averagePeakLevel) + " variance=" + String(variance) +
+                " avgPkLv=" + String(averagePeakLevel) + " variance=" + String(variance, 5) +
                 " samples=" + String(averagePeakLevelCounter));
             } else {
                 Serial.println( "$ping cal=0 gain=" + String(optimalGain) +
                 " peakLevel=" + String(peakLevel) + " error=" + String(error) +
-                " avgPkLv=" + String(averagePeakLevel) + " variance=" + String(variance) +
+                " avgPkLv=" + String(averagePeakLevel) + " variance=" + String(variance, 5) +
                 " samples=" + String(averagePeakLevelCounter));
             }
             averagePeakLevelCounter = 0;
             averagePeakLevel = 0;
+
+            averagePeakLevelSquaredCounter = 0;
+            averagePeakLevelSquared = 0;
 
             Serial.flush();
         }
@@ -303,9 +306,10 @@ bool GainControl::checkCalibration( void ){
     this->GainControl::calculateVariance();
 
     if ( (averagePeakLevel > (desiredPeak-validMean))
-                                                && (averagePeakLevel < (desiredPeak + validMean))
-                                                && (variance < validVariance)
-                                                && (variance > (-1*validVariance)) ) {
+        && (averagePeakLevel < (desiredPeak + validMean))
+        && (variance < validVariance)
+        && (variance > (-1*validVariance)) ) {
+
         return true;
     } else {
         return false;

--- a/preprocessor_firmware/src/GainControl.h
+++ b/preprocessor_firmware/src/GainControl.h
@@ -52,11 +52,20 @@ class GainControl : public PeakDetector{
         //Method to manually set gain
         void setGain( float gain );
 
+        //Method to set the valid mean for calibration
+        void setValidMean( float _validMean );
+
+        //Method to set the valid variance for calibration
+        void setValidVariance( float _validVariance);
+
         //Set the amount the gain will be nudged after the nudge gain duration (dB)
         void setNudgeGainValue( float gain );
 
         //Get the current desired peak of the controller
         float getDesiredPeak( void );
+
+        //Get the current status of hold gain
+        bool getHoldGain( void );
 
         //Get the current "optimized" gain in dB as calculated by the Controller
         float getCurrentOptimalGain( void );
@@ -76,6 +85,12 @@ class GainControl : public PeakDetector{
 
         //Check if the gain is calibrated currently
         bool checkCalibration( void );
+
+        //Get the valid mean
+        float getValidMean( void );
+
+        //Get the valid variance
+        float getValidVariance( void );
 
 
     //Methods and variables that "Black Box" users should not be conserned with.
@@ -99,8 +114,15 @@ class GainControl : public PeakDetector{
         float error;  // error for the proportional gain
         float sumError; // error for the integral (summation) gain
 
+        void calculateVariance( void );
         double averagePeakLevel; //Variable to get the average peakLevel of the signal
         uint16_t averagePeakLevelCounter;
+        double averagePeakLevelSquared;
+        uint16_t averagePeakLevelSquaredCounter;
+        double variance;
+
+        float validMean;
+        float validVariance;
 
         //Returns the time elasped since calling millis on a 'timer'. A simple Helper function
         unsigned long elapsedTime( unsigned long millisTimer );

--- a/preprocessor_firmware/src/constants.h
+++ b/preprocessor_firmware/src/constants.h
@@ -16,7 +16,7 @@
 #define NUDGE_VALUE 0.1 //How much to nudge the gain up after the NUDGE_GAIN_DURATION
 //Default mean and variance values for the calibration flag
 #define DEFAULT_VALIDMEAN 0.25 //How far the mean can deviate from the desired peak value
-#define DEFAULT_VALIDVARIANCE 0.25 //How large the variance can be
+#define DEFAULT_VALIDVARIANCE 0.005 //How large the variance can be
 
 //Initializing constants for the peak detector
 #define Vref 2.5             //ADC reference

--- a/preprocessor_firmware/src/constants.h
+++ b/preprocessor_firmware/src/constants.h
@@ -14,6 +14,9 @@
 #define NUDGE_GAIN_DURATION 250  //How long of invalid ping until we "nudge" gain up
 #define INVALID_PING_DURATION 5000 //How long of invalid ping until gain is invalid
 #define NUDGE_VALUE 0.1 //How much to nudge the gain up after the NUDGE_GAIN_DURATION
+//Default mean and variance values for the calibration flag
+#define DEFAULT_VALIDMEAN 0.25 //How far the mean can deviate from the desired peak value
+#define DEFAULT_VALIDVARIANCE 0.25 //How large the variance can be
 
 //Initializing constants for the peak detector
 #define Vref 2.5             //ADC reference


### PR DESCRIPTION
-Gain Controller uses variance of the signal for calibration judgment. No longer uses the "error" of the last sample. Still uses the mean. 

-The thresholds for the variance and the mean are tunable/compatible with the comm interface.

-Added the validVariance and validMean to the docs for the comm interface on the teensy. These variables are for computing the "calibrated" or "cal" flag that is transmitted at the end of a ping.