### PR TITLE
Comp

### DIFF
--- a/preprocessor_firmware/src/CommInterface.cpp
+++ b/preprocessor_firmware/src/CommInterface.cpp
@@ -204,11 +204,13 @@ void CommInterface::getArgument(){
     if (argument1Length > 32){
 
         //if the variable was "iSaturation", then there should have been a ' '. Invalid if so.
+        /*
         if( variableIndex == 4){
             messageReceived = false;
             message = String("");
             return;
         }
+        */
 
         argument1Length = 0;
         //Go through the argument and get the length of it
@@ -233,7 +235,9 @@ void CommInterface::getArgument(){
         argument1String = String(message);
 
     //This else is for the case of two arguments -> a space was found after argument1
-    } else {
+    }
+    /*
+    else {
 
         //Currently only "iSaturation" requires two arguments
         if ( variableIndex == 4 ){
@@ -267,7 +271,9 @@ void CommInterface::getArgument(){
             message = String("");
             return;
         }
+
     }
+    */
 }
 
 //This method is called when a second argument is to be gathered from message
@@ -335,7 +341,8 @@ void CommInterface::setValue( void ){
             gainControl->setIntegralGain(output_float );
             break;
         case 4:
-            gainControl->setIntegralSaturation(output_float, output2_float);
+            //gainControl->setIntegralSaturation(output_float, output2_float);
+            gainControl->setIntegralSaturation(output_float);
             break;
         case 5:
             gainControl->setFloorGainDuration(output_int);
@@ -397,6 +404,9 @@ void CommInterface::sendLocalVariable( void ){
             break;
         case 3:
             output_float = gainControl->getIntegralGain();
+            break;
+        case 4:
+            output_float = gainControl->getISaturation();
             break;
         case 11:
             output_float = gainControl->getCurrentOptimalGain();

--- a/preprocessor_firmware/src/GainControl.cpp
+++ b/preprocessor_firmware/src/GainControl.cpp
@@ -329,6 +329,11 @@ void GainControl::setIntegralGain( float gain ){
     iGain = gain;
 }
 
+void GainControl::setIntegralSaturation(float absBound){
+    iErrorMax = absBound;
+    iErrorMin = -1*absBound;
+}
+
 void GainControl::setIntegralSaturation( float lowerBound, float upperBound){
     iErrorMax = upperBound;
     iErrorMin = lowerBound;
@@ -373,6 +378,10 @@ float GainControl::getDesiredPeak( void ){
 
 bool GainControl::getHoldGain( void ){
     return holdGainFlag;
+}
+
+float GainControl::getISaturation( void ){
+    return iErrorMax;
 }
 
 float GainControl::getCurrentOptimalGain( void ){

--- a/preprocessor_firmware/src/GainControl.h
+++ b/preprocessor_firmware/src/GainControl.h
@@ -35,6 +35,7 @@ class GainControl : public PeakDetector{
         void setIntegralGain( float gain );
 
         //Set the limits of the integral
+        void setIntegralSaturation( float absBound );
         void setIntegralSaturation( float lowerBound, float upperBound );
 
         //Set the time the gain should be floored after reading the ping (ms)
@@ -69,6 +70,9 @@ class GainControl : public PeakDetector{
 
         //Get the current "optimized" gain in dB as calculated by the Controller
         float getCurrentOptimalGain( void );
+
+        //Get the value of the iSaturation, returns iErrorMax
+        float getISaturation( void );
 
         //Get the current "Peak Level" in Volts as calculated by the peak detector
         float getCurrentPeakLevel( void );

--- a/preprocessor_firmware/src/constants.h
+++ b/preprocessor_firmware/src/constants.h
@@ -24,7 +24,7 @@
 #define PINGVALIDSTART 200   //offset for the start of the ping (microseconds)
 #define PINGVALIDEND 1500    //offset for the end of the ping (microseconds)
 //A valid ping is 2*PEAK_NOISE
-#define PEAK_NOISE 0.4
+#define PEAK_NOISE 0.6
 //Power rail noise is 40mV
 
 //Constants for the filter

--- a/preprocessor_firmware/src/constants.h
+++ b/preprocessor_firmware/src/constants.h
@@ -6,7 +6,7 @@
 #define DESIRED_PEAK 1.0 //The intial target output in Vpp.
 #define DC_BIAS 0.97  //Peak Detector reading without any input to the sonar board
 //Initial gains for the controller
-#define P_GAIN 0.1   //The error at the moment of getting the peak value.
+#define P_GAIN 0.2   //The error at the moment of getting the peak value.
 #define I_GAIN 0.01  //Sums the error over time
 #define MAX_I_ERROR 0.5 //Saturates the integral error.
 //Initial durations in milliseconds


### PR DESCRIPTION
-iSaturation is 1 argument. So the sum of the error will only go from -argument to argument. 

-To make this change quick as possible, I broke the ability to enter 2 arguments. So dont do that.

-You can now also get iSaturation.

